### PR TITLE
Add ICM-20948 IMU ROS 2 integration and rosbag recording

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic==2.9.2
 pymodbus>=3.10
 python-dotenv==1.0.1
 pyserial==3.5
+smbus2

--- a/src/horseshitbot/config/params.yaml
+++ b/src/horseshitbot/config/params.yaml
@@ -144,12 +144,22 @@ lidar_node:
   ros__parameters:
     port: "/dev/lidar"
     baud: 230400
-    auto_start: true
+    auto_start: false
     publish_hz: 5.0
     frame_id: "laser"
     range_min: 0.02
     range_max: 12.0
     scan_bins: 720
+
+imu_node:
+  ros__parameters:
+    bus: 7
+    address: 105
+    publish_hz: 50.0
+    frame_id: "imu_link"
+    accel_full_scale_g: 2
+    gyro_full_scale_dps: 250
+    use_magnetometer: true
 
 perception_recorder:
   ros__parameters:
@@ -172,5 +182,8 @@ mapping_recorder:
     default_topics:
       - "/scan"
       - "/odom"
+      - "/imu/data_raw"
+      - "/imu/mag"
+      - "/imu/temperature"
       - "/tf"
       - "/tf_static"

--- a/src/horseshitbot/config/params.yaml
+++ b/src/horseshitbot/config/params.yaml
@@ -144,7 +144,7 @@ lidar_node:
   ros__parameters:
     port: "/dev/lidar"
     baud: 230400
-    auto_start: false
+    auto_start: true
     publish_hz: 5.0
     frame_id: "laser"
     range_min: 0.02

--- a/src/horseshitbot/horseshitbot/drivers/icm20948.py
+++ b/src/horseshitbot/horseshitbot/drivers/icm20948.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Minimal ICM-20948 I2C driver used by the ROS 2 IMU node."""
+
+from __future__ import annotations
+
+import time
+
+# ICM-20948
+ICM_WHO_AM_I = 0xEA
+REG_BANK_SEL = 0x7F
+
+# Bank 0
+B0_WHO_AM_I = 0x00
+B0_USER_CTRL = 0x03
+B0_PWR_MGMT_1 = 0x06
+B0_PWR_MGMT_2 = 0x07
+B0_INT_PIN_CFG = 0x0F
+B0_ACCEL_XOUT_H = 0x2D
+
+# Bank 2
+B2_GYRO_CONFIG_1 = 0x01
+B2_ACCEL_CONFIG = 0x14
+
+# AK09916 magnetometer
+AK_ADDR = 0x0C
+AK_WHO_AM_I = 0x09
+AK_WIA2 = 0x01
+AK_ST1 = 0x10
+AK_HXL = 0x11
+AK_ST2 = 0x18
+AK_CNTL2 = 0x31
+AK_CNTL3 = 0x32
+
+ACCEL_FS_MAP = {
+    2: (0x00, 16384.0),
+    4: (0x01, 8192.0),
+    8: (0x02, 4096.0),
+    16: (0x03, 2048.0),
+}
+
+GYRO_FS_MAP = {
+    250: (0x00, 131.0),
+    500: (0x01, 65.5),
+    1000: (0x02, 32.8),
+    2000: (0x03, 16.4),
+}
+
+MAG_UT_PER_LSB = 0.15
+
+
+class ICM20948:
+    """Low-level reader for the ICM-20948 and its AK09916 magnetometer."""
+
+    def __init__(self, bus: int, address: int = 0x68) -> None:
+        import smbus2
+
+        self.bus_number = bus
+        self.address = address
+        self.bus = smbus2.SMBus(bus)
+
+        self._bank = -1
+        self.accel_lsb_per_g: float | None = None
+        self.gyro_lsb_per_dps: float | None = None
+
+    def close(self) -> None:
+        self.bus.close()
+
+    def _set_bank(self, bank: int, address: int | None = None) -> None:
+        if address is None:
+            address = self.address
+
+        if address == self.address and self._bank == bank:
+            return
+
+        self.bus.write_byte_data(
+            address,
+            REG_BANK_SEL,
+            (bank & 0x03) << 4,
+        )
+
+        if address == self.address:
+            self._bank = bank
+
+        time.sleep(0.001)
+
+    def read_reg(
+        self,
+        bank: int,
+        register: int,
+        address: int | None = None,
+    ) -> int:
+        if address is None:
+            address = self.address
+
+        self._set_bank(bank, address)
+        return self.bus.read_byte_data(address, register)
+
+    def read_block(
+        self,
+        bank: int,
+        register: int,
+        length: int,
+        address: int | None = None,
+    ) -> bytes:
+        if address is None:
+            address = self.address
+
+        self._set_bank(bank, address)
+
+        return bytes(
+            self.bus.read_i2c_block_data(
+                address,
+                register,
+                length,
+            )
+        )
+
+    def write_reg(
+        self,
+        bank: int,
+        register: int,
+        value: int,
+        address: int | None = None,
+    ) -> None:
+        if address is None:
+            address = self.address
+
+        self._set_bank(bank, address)
+        self.bus.write_byte_data(address, register, value & 0xFF)
+
+    def who_am_i(self) -> int:
+        return self.read_reg(0, B0_WHO_AM_I)
+
+    def initialize(
+        self,
+        accel_full_scale_g: int = 2,
+        gyro_full_scale_dps: int = 250,
+    ) -> None:
+        if accel_full_scale_g not in ACCEL_FS_MAP:
+            raise ValueError(
+                f"Unsupported accelerometer range: {accel_full_scale_g}"
+            )
+
+        if gyro_full_scale_dps not in GYRO_FS_MAP:
+            raise ValueError(
+                f"Unsupported gyroscope range: {gyro_full_scale_dps}"
+            )
+
+        detected_id = self.who_am_i()
+        if detected_id != ICM_WHO_AM_I:
+            raise RuntimeError(
+                f"Unexpected ICM-20948 WHO_AM_I value: "
+                f"0x{detected_id:02X}; expected 0x{ICM_WHO_AM_I:02X}"
+            )
+
+        # Reset.
+        self.write_reg(0, B0_PWR_MGMT_1, 0x80)
+        time.sleep(0.1)
+
+        # Reset invalidates the cached bank.
+        self._bank = -1
+
+        # Wake and use the automatic clock source.
+        self.write_reg(0, B0_PWR_MGMT_1, 0x01)
+        time.sleep(0.05)
+
+        # Enable all accelerometer and gyroscope axes.
+        self.write_reg(0, B0_PWR_MGMT_2, 0x00)
+
+        accel_bits, self.accel_lsb_per_g = ACCEL_FS_MAP[
+            accel_full_scale_g
+        ]
+        gyro_bits, self.gyro_lsb_per_dps = GYRO_FS_MAP[
+            gyro_full_scale_dps
+        ]
+
+        # FCHOICE=1 enables the digital low-pass filter.
+        self.write_reg(
+            2,
+            B2_ACCEL_CONFIG,
+            (accel_bits << 1) | 0x01,
+        )
+        self.write_reg(
+            2,
+            B2_GYRO_CONFIG_1,
+            (gyro_bits << 1) | 0x01,
+        )
+
+        time.sleep(0.01)
+
+    @staticmethod
+    def _signed_int16_be(high: int, low: int) -> int:
+        value = (high << 8) | low
+        return value - 65536 if value & 0x8000 else value
+
+    @staticmethod
+    def _signed_int16_le(low: int, high: int) -> int:
+        value = (high << 8) | low
+        return value - 65536 if value & 0x8000 else value
+
+    def read_accel_gyro_temp(self) -> dict:
+        if (
+            self.accel_lsb_per_g is None
+            or self.gyro_lsb_per_dps is None
+        ):
+            raise RuntimeError("ICM-20948 has not been initialized")
+
+        data = self.read_block(0, B0_ACCEL_XOUT_H, 14)
+
+        raw_values = [
+            self._signed_int16_be(data[index], data[index + 1])
+            for index in range(0, 12, 2)
+        ]
+
+        temperature_raw = self._signed_int16_be(data[12], data[13])
+
+        ax, ay, az, gx, gy, gz = raw_values
+
+        return {
+            "accel_g": (
+                ax / self.accel_lsb_per_g,
+                ay / self.accel_lsb_per_g,
+                az / self.accel_lsb_per_g,
+            ),
+            "gyro_dps": (
+                gx / self.gyro_lsb_per_dps,
+                gy / self.gyro_lsb_per_dps,
+                gz / self.gyro_lsb_per_dps,
+            ),
+            "temp_c": temperature_raw / 333.87 + 21.0,
+        }
+
+    def enable_magnetometer_bypass(self) -> None:
+        # Disable the ICM's internal auxiliary I2C master.
+        self.write_reg(0, B0_USER_CTRL, 0x00)
+
+        # Expose the AK09916 directly on the main I2C bus.
+        self.write_reg(0, B0_INT_PIN_CFG, 0x02)
+
+        time.sleep(0.01)
+
+    def magnetometer_who_am_i(self) -> int:
+        return self.bus.read_byte_data(AK_ADDR, AK_WIA2)
+
+    def initialize_magnetometer(self) -> None:
+        detected_id = self.magnetometer_who_am_i()
+
+        if detected_id != AK_WHO_AM_I:
+            raise RuntimeError(
+                f"Unexpected AK09916 WHO_AM_I value: "
+                f"0x{detected_id:02X}; expected 0x{AK_WHO_AM_I:02X}"
+            )
+
+        # Soft reset.
+        self.bus.write_byte_data(AK_ADDR, AK_CNTL3, 0x01)
+        time.sleep(0.01)
+
+        # Continuous measurement mode, 100 Hz.
+        self.bus.write_byte_data(AK_ADDR, AK_CNTL2, 0x08)
+        time.sleep(0.01)
+
+    def read_magnetometer(self, timeout: float = 0.03) -> dict:
+        deadline = time.monotonic() + timeout
+
+        while time.monotonic() < deadline:
+            status_1 = self.bus.read_byte_data(AK_ADDR, AK_ST1)
+
+            if status_1 & 0x01:
+                break
+
+            time.sleep(0.002)
+        else:
+            raise TimeoutError("AK09916 data-ready timeout")
+
+        data = self.bus.read_i2c_block_data(AK_ADDR, AK_HXL, 6)
+
+        # ST2 must be read to release/latch the next measurement.
+        status_2 = self.bus.read_byte_data(AK_ADDR, AK_ST2)
+        overflow = bool(status_2 & 0x08)
+
+        mx_raw = self._signed_int16_le(data[0], data[1])
+        my_raw = self._signed_int16_le(data[2], data[3])
+        mz_raw = self._signed_int16_le(data[4], data[5])
+
+        return {
+            "mag_ut": (
+                mx_raw * MAG_UT_PER_LSB,
+                my_raw * MAG_UT_PER_LSB,
+                mz_raw * MAG_UT_PER_LSB,
+            ),
+            "overflow": overflow,
+        }

--- a/src/horseshitbot/horseshitbot/nodes/bag_recorder_node.py
+++ b/src/horseshitbot/horseshitbot/nodes/bag_recorder_node.py
@@ -47,6 +47,9 @@ _TOPIC_TYPE_MAP = {
     # Mapping — lidar + odometry
     "/scan": "sensor_msgs/msg/LaserScan",
     "/odom": "nav_msgs/msg/Odometry",
+    "/imu/data_raw": "sensor_msgs/msg/Imu",
+    "/imu/mag": "sensor_msgs/msg/MagneticField",
+    "/imu/temperature": "sensor_msgs/msg/Temperature",
     "/tf": "tf2_msgs/msg/TFMessage",
     "/tf_static": "tf2_msgs/msg/TFMessage",
     # Navigation
@@ -75,6 +78,9 @@ _TOPIC_GROUPS = {
     "Mapping": [
         "/scan",
         "/odom",
+        "/imu/data_raw",
+        "/imu/mag",
+        "/imu/temperature",
         "/tf",
         "/tf_static",
     ],

--- a/src/horseshitbot/horseshitbot/nodes/imu_node.py
+++ b/src/horseshitbot/horseshitbot/nodes/imu_node.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""ROS 2 node for the ICM-20948 IMU."""
+
+from __future__ import annotations
+
+import math
+import time
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import qos_profile_sensor_data
+from sensor_msgs.msg import Imu, MagneticField, Temperature
+
+from horseshitbot.drivers.icm20948 import ICM20948
+
+
+GRAVITY_M_S2 = 9.80665
+DEGREES_TO_RADIANS = math.pi / 180.0
+MICROTESLA_TO_TESLA = 1.0e-6
+
+
+class ImuNode(Node):
+    def __init__(self) -> None:
+        super().__init__("imu_node")
+
+        self.declare_parameter("bus", 7)
+        self.declare_parameter("address", 105)
+        self.declare_parameter("publish_hz", 50.0)
+        self.declare_parameter("frame_id", "imu_link")
+        self.declare_parameter("accel_full_scale_g", 2)
+        self.declare_parameter("gyro_full_scale_dps", 250)
+        self.declare_parameter("use_magnetometer", True)
+
+        bus = int(self.get_parameter("bus").value)
+        address = int(self.get_parameter("address").value)
+        publish_hz = float(self.get_parameter("publish_hz").value)
+
+        self._frame_id = str(self.get_parameter("frame_id").value)
+        self._use_magnetometer = bool(
+            self.get_parameter("use_magnetometer").value
+        )
+
+        accel_full_scale_g = int(
+            self.get_parameter("accel_full_scale_g").value
+        )
+        gyro_full_scale_dps = int(
+            self.get_parameter("gyro_full_scale_dps").value
+        )
+
+        if publish_hz <= 0.0:
+            raise ValueError("publish_hz must be greater than zero")
+
+        self._driver = ICM20948(
+            bus=bus,
+            address=address,
+        )
+
+        self._driver.initialize(
+            accel_full_scale_g=accel_full_scale_g,
+            gyro_full_scale_dps=gyro_full_scale_dps,
+        )
+
+        self._magnetometer_available = False
+
+        if self._use_magnetometer:
+            try:
+                self._driver.enable_magnetometer_bypass()
+                self._driver.initialize_magnetometer()
+                self._magnetometer_available = True
+            except (OSError, RuntimeError) as exc:
+                self.get_logger().warning(
+                    f"Magnetometer unavailable; continuing with "
+                    f"accelerometer and gyroscope only: {exc}"
+                )
+
+        self._imu_publisher = self.create_publisher(
+            Imu,
+            "/imu/data_raw",
+            qos_profile_sensor_data,
+        )
+
+        self._mag_publisher = self.create_publisher(
+            MagneticField,
+            "/imu/mag",
+            qos_profile_sensor_data,
+        )
+
+        self._temperature_publisher = self.create_publisher(
+            Temperature,
+            "/imu/temperature",
+            qos_profile_sensor_data,
+        )
+
+        self._last_read_error_time = 0.0
+        self._last_mag_error_time = 0.0
+
+        self._timer = self.create_timer(
+            1.0 / publish_hz,
+            self._publish_measurement,
+        )
+
+        self.get_logger().info(
+            f"ICM-20948 initialized on /dev/i2c-{bus}, "
+            f"address=0x{address:02X}, "
+            f"rate={publish_hz:.1f} Hz, "
+            f"frame={self._frame_id}, "
+            f"magnetometer={self._magnetometer_available}"
+        )
+
+    def _publish_measurement(self) -> None:
+        try:
+            sample = self._driver.read_accel_gyro_temp()
+        except (OSError, RuntimeError) as exc:
+            self._log_throttled_read_error(str(exc))
+            return
+
+        stamp = self.get_clock().now().to_msg()
+
+        ax_g, ay_g, az_g = sample["accel_g"]
+        gx_dps, gy_dps, gz_dps = sample["gyro_dps"]
+
+        imu_message = Imu()
+        imu_message.header.stamp = stamp
+        imu_message.header.frame_id = self._frame_id
+
+        # This node publishes raw measurements and does not calculate
+        # an orientation quaternion.
+        imu_message.orientation.w = 1.0
+        imu_message.orientation_covariance[0] = -1.0
+
+        imu_message.linear_acceleration.x = ax_g * GRAVITY_M_S2
+        imu_message.linear_acceleration.y = ay_g * GRAVITY_M_S2
+        imu_message.linear_acceleration.z = az_g * GRAVITY_M_S2
+
+        imu_message.angular_velocity.x = gx_dps * DEGREES_TO_RADIANS
+        imu_message.angular_velocity.y = gy_dps * DEGREES_TO_RADIANS
+        imu_message.angular_velocity.z = gz_dps * DEGREES_TO_RADIANS
+
+        self._imu_publisher.publish(imu_message)
+
+        temperature_message = Temperature()
+        temperature_message.header.stamp = stamp
+        temperature_message.header.frame_id = self._frame_id
+        temperature_message.temperature = float(sample["temp_c"])
+        temperature_message.variance = 0.0
+
+        self._temperature_publisher.publish(temperature_message)
+
+        if self._magnetometer_available:
+            self._publish_magnetometer(stamp)
+
+    def _publish_magnetometer(self, stamp) -> None:
+        try:
+            magnetometer = self._driver.read_magnetometer(timeout=0.03)
+        except (OSError, TimeoutError) as exc:
+            now = time.monotonic()
+
+            if now - self._last_mag_error_time >= 5.0:
+                self.get_logger().warning(
+                    f"Magnetometer read failed: {exc}"
+                )
+                self._last_mag_error_time = now
+
+            return
+
+        if magnetometer["overflow"]:
+            now = time.monotonic()
+
+            if now - self._last_mag_error_time >= 5.0:
+                self.get_logger().warning(
+                    "Magnetometer reported measurement overflow"
+                )
+                self._last_mag_error_time = now
+
+            return
+
+        mx_ut, my_ut, mz_ut = magnetometer["mag_ut"]
+
+        magnetic_message = MagneticField()
+        magnetic_message.header.stamp = stamp
+        magnetic_message.header.frame_id = self._frame_id
+
+        magnetic_message.magnetic_field.x = mx_ut * MICROTESLA_TO_TESLA
+        magnetic_message.magnetic_field.y = my_ut * MICROTESLA_TO_TESLA
+        magnetic_message.magnetic_field.z = mz_ut * MICROTESLA_TO_TESLA
+
+        self._mag_publisher.publish(magnetic_message)
+
+    def _log_throttled_read_error(self, error: str) -> None:
+        now = time.monotonic()
+
+        if now - self._last_read_error_time >= 5.0:
+            self.get_logger().error(f"ICM-20948 read failed: {error}")
+            self._last_read_error_time = now
+
+    def destroy_node(self) -> None:
+        try:
+            self._driver.close()
+        finally:
+            super().destroy_node()
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+
+    node = None
+
+    try:
+        node = ImuNode()
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if node is not None:
+            node.destroy_node()
+
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/horseshitbot/horseshitbot/web/static/app.js
+++ b/src/horseshitbot/horseshitbot/web/static/app.js
@@ -666,7 +666,13 @@ function renderTopicPicker(profile) {
       cb.className = "topic-cb";
       lbl.appendChild(cb);
       const span = document.createElement("span");
-      span.textContent = topic.split("/").pop();
+
+      if (topic.startsWith("/imu/")) {
+        span.textContent = topic.slice(1);
+      } else {
+        span.textContent = topic.split("/").pop();
+      }
+
       span.title = topic;
       lbl.appendChild(span);
       group.appendChild(lbl);

--- a/src/horseshitbot/launch/robot_launch.py
+++ b/src/horseshitbot/launch/robot_launch.py
@@ -5,6 +5,7 @@ Arguments:
   enable_camera:=true/false   — enable/disable RealSense + bag recorder (default true)
   enable_mks:=true/false      — enable/disable MKS bus node (default true)
   enable_lidar:=true/false    — enable/disable lidar node (default true)
+  enable_imu:=true/false      — enable/disable ICM-20948 IMU node (default true)
 
 Example:
   ros2 launch horseshitbot robot_launch.py enable_camera:=false enable_mks:=false
@@ -30,7 +31,8 @@ def _launch_setup(context):
     enable_camera = LaunchConfiguration("enable_camera").perform(context).lower() == "true"
     enable_mks = LaunchConfiguration("enable_mks").perform(context).lower() == "true"
     enable_lidar = LaunchConfiguration("enable_lidar").perform(context).lower() == "true"
-
+    enable_imu = LaunchConfiguration("enable_imu").perform(context).lower() == "true"
+    
     nodes = []
 
     if enable_mks:
@@ -130,6 +132,33 @@ def _launch_setup(context):
         ),
     ]
 
+    if enable_imu:
+        nodes.append(Node(
+            package="horseshitbot",
+            executable="imu_node",
+            name="imu_node",
+            parameters=[params_file],
+            output="screen",
+        ))
+
+    # Bag recorders
+    nodes += [
+        Node(
+            package="horseshitbot",
+            executable="bag_recorder_node",
+            name="perception_recorder",
+            parameters=[params_file],
+            output="screen",
+        ),
+        Node(
+            package="horseshitbot",
+            executable="bag_recorder_node",
+            name="mapping_recorder",
+            parameters=[params_file],
+            output="screen",
+        ),
+    ]
+
     if enable_camera:
         from launch.actions import IncludeLaunchDescription
         rs_launch_dir = os.path.join(
@@ -161,6 +190,7 @@ def generate_launch_description():
         DeclareLaunchArgument("enable_camera", default_value="true"),
         DeclareLaunchArgument("enable_mks", default_value="true"),
         DeclareLaunchArgument("enable_lidar", default_value="true"),
+        DeclareLaunchArgument("enable_imu", default_value="true"),
         DeclareLaunchArgument("params_file", default_value=""),
         OpaqueFunction(function=_launch_setup),
     ])

--- a/src/horseshitbot/setup.py
+++ b/src/horseshitbot/setup.py
@@ -42,6 +42,7 @@ setup(
             "bag_recorder_node = horseshitbot.nodes.bag_recorder_node:main",
             "yolo_detector_node = horseshitbot.nodes.yolo_detector_node:main",
             "lidar_node = horseshitbot.nodes.lidar_node:main",
+            "imu_node = horseshitbot.nodes.imu_node:main",
         ],
     },
 )


### PR DESCRIPTION
## Summary

Adds support for the installed ICM-20948 IMU on I²C bus 7 at address `0x69`.

## Changes

- Added a reusable ICM-20948/AK09916 I²C driver.
- Added `imu_node` publishing:
  - `/imu/data_raw`
  - `/imu/mag`
  - `/imu/temperature`
- Converted sensor values to standard ROS units.
- Added IMU parameters and an `enable_imu` launch option.
- Added IMU topics to the mapping rosbag recorder and web topic selector.
- Added the required `smbus2` dependency and ROS executable registration.

## Testing

- Verified accelerometer, gyroscope, magnetometer, and temperature readings with the standalone test script.
- Verified all three ROS topics publish at approximately 50 Hz.
- Verified a 20-second mapping bag recorded 1024 messages for each IMU topic.